### PR TITLE
calling mongoc_cleanup only after mongoc_init 

### DIFF
--- a/Source/USemLog/Classes/SLMetadataWriter.h
+++ b/Source/USemLog/Classes/SLMetadataWriter.h
@@ -112,6 +112,11 @@ private:
 	// Set when manager is finished
 	bool bIsFinished;
 
+	// Flag to show if mongoc has been called
+	bool bIsMongoInitCalled;
+
+
+
 #if SL_WITH_LIBMONGO_C
 	// Server uri
 	mongoc_uri_t* uri;

--- a/Source/USemLog/Classes/WorldState/SLWorldStateWriterMongoC.h
+++ b/Source/USemLog/Classes/WorldState/SLWorldStateWriterMongoC.h
@@ -72,6 +72,9 @@ private:
 	// Add pose to document
 	void AddPoseChild(const FVector& InLoc, const FQuat& InQuat, bson_t* out_doc);
 
+	// Flag to show if mongoc has been called
+	bool bIsMongoInitCalled;
+
 private:
 	// Server uri
 	mongoc_uri_t* uri;

--- a/Source/USemLog/Private/SLMetadataWriter.cpp
+++ b/Source/USemLog/Private/SLMetadataWriter.cpp
@@ -13,6 +13,7 @@ FSLMetadataWriter::FSLMetadataWriter()
 	bIsInit = false;
 	bIsStarted = false;
 	bIsFinished = false;
+	bIsMongoInitCalled = false;
 }
 
 // Dtor
@@ -26,7 +27,13 @@ FSLMetadataWriter::~FSLMetadataWriter()
 	mongoc_database_destroy(database);
 	mongoc_uri_destroy(uri);
 	mongoc_client_destroy(client);
-	mongoc_cleanup();
+	if(bIsMongoInitCalled)
+	{
+		mongoc_cleanup();
+		bIsMongoInitCalled = false;
+	}else{
+		UE_LOG(LogTemp, Warning, TEXT("%s::%d Mongo Init hasn't been called before dtor, skipping cleanup"), *FString(__func__), __LINE__);
+	}
 #endif //SL_WITH_LIBMONGO_C
 }
 
@@ -145,6 +152,7 @@ bool FSLMetadataWriter::Connect(const FString& DBName, const FString& EpisodeId,
 #if SL_WITH_LIBMONGO_C
 	// Required to initialize libmongoc's internals	
 	mongoc_init();
+	bIsMongoInitCalled = true;
 
 	// Stores any error that might appear during the connection
 	bson_error_t error;

--- a/Source/USemLog/Private/WorldState/SLWorldStateWriterMongoC.cpp
+++ b/Source/USemLog/Private/WorldState/SLWorldStateWriterMongoC.cpp
@@ -9,6 +9,7 @@
 FSLWorldStateWriterMongoC::FSLWorldStateWriterMongoC()
 {
 	bIsInit = false;
+	bIsMongoInitCalled = false;
 }
 
 // Init constr
@@ -28,7 +29,13 @@ FSLWorldStateWriterMongoC::~FSLWorldStateWriterMongoC()
 	mongoc_database_destroy(database);
 	mongoc_uri_destroy(uri);
 	mongoc_client_destroy(client);
-	mongoc_cleanup();
+	if(bIsMongoInitCalled)
+	{
+		mongoc_cleanup();
+		bIsMongoInitCalled = false;
+	}else{
+		UE_LOG(LogTemp, Warning, TEXT("%s::%d Mongo Init hasn't been called before dtor, skipping cleanup"), *FString(__func__), __LINE__);
+	}
 #endif //SL_WITH_LIBMONGO_C
 }
 
@@ -104,6 +111,7 @@ bool FSLWorldStateWriterMongoC::Connect(const FString& DBName, const FString& Ep
 #if SL_WITH_LIBMONGO_C
 	// Required to initialize libmongoc's internals	
 	mongoc_init();
+	bIsMongoInitCalled = true;
 
 	// Stores any error that might appear during the connection
 	bson_error_t error;

--- a/Source/USemLogVision/Classes/SLVisImageWriterInterface.h
+++ b/Source/USemLogVision/Classes/SLVisImageWriterInterface.h
@@ -291,4 +291,6 @@ public:
 protected:
 	// Flag to show if it is valid
 	bool bIsInit;
+	// Flag to show if mongoc has been called
+	bool bIsMongoInitCalled;
 };

--- a/Source/USemLogVision/Private/SLVisImageWriterMongoC.cpp
+++ b/Source/USemLogVision/Private/SLVisImageWriterMongoC.cpp
@@ -7,6 +7,7 @@
 USLVisImageWriterMongoC::USLVisImageWriterMongoC()
 {
 	bIsInit = false;
+	bIsMongoInitCalled = false;
 }
 
 // Dtor
@@ -19,7 +20,14 @@ USLVisImageWriterMongoC::~USLVisImageWriterMongoC()
 	mongoc_database_destroy(database);
 	mongoc_uri_destroy(uri);
 	mongoc_client_destroy(client);
-	mongoc_cleanup();
+
+	if(bIsMongoInitCalled)
+	{
+		mongoc_cleanup();
+		bIsMongoInitCalled = false;
+	}else{
+		UE_LOG(LogTemp, Warning, TEXT("%s::%d Mongo Init hasn't been called before dtor, skipping cleanup"), *FString(__func__), __LINE__);
+	}
 #endif //SLVIS_WITH_LIBMONGO_C
 }
 
@@ -243,6 +251,7 @@ bool USLVisImageWriterMongoC::Connect(const FString& DBName, const FString& Epis
 #if SLVIS_WITH_LIBMONGO_C
 	// Required to initialize libmongoc's internals	
 	mongoc_init();
+	bIsMongoInitCalled = true;
 
 	// Stores any error that might appear during the connection
 	bson_error_t error;	


### PR DESCRIPTION
Some classes call mongoc_cleanup in their dtors without ensure that mongoc_init has been called before.
On Linux this leads to problems as some mutexes are tried to be destroyed before they really have been initialized. This is why a new flag has been introduced that is set immediately after the call to mongoc_init in the classes concerned.