### PR TITLE
add uploading assets to mongodb gridfs and downloading assets from gr…

### DIFF
--- a/Source/USemLog/Classes/Editor/SLAssetDBHandler.h
+++ b/Source/USemLog/Classes/Editor/SLAssetDBHandler.h
@@ -5,6 +5,7 @@
 
 #include "CoreMinimal.h"
 #include "Editor/SLEditorStructs.h"
+#include "AssetData.h"
 #if SL_WITH_LIBMONGO_C
 	THIRD_PARTY_INCLUDES_START
 	#if PLATFORM_WINDOWS
@@ -46,6 +47,18 @@ private:
 	// Download assets
 	void Download();
 
+	// Upload all files under the specified folder to the GridFS
+	void UploadAllFileToGridFS(const FString& Dir);
+
+	// Upload one single file to GridFS
+	bool UploadFileToGridFS(const FString& Path, const FString& FileName, FString& InId);
+
+	// Write file id and path in the document
+	bool WriteFilesToDocument(TMap<FString, FString> Files);
+	
+	// Download file from GridFS given the file id
+	bool DownloadFileFromGridFS(const FString& Path, const FString& Id);
+		
 #if SL_WITH_LIBMONGO_C
 	// Save image to gridfs, get the file oid and return true if succeeded
 	bool AddToGridFs(const TArray<uint8>& InData, bson_oid_t* out_oid) const;
@@ -54,6 +67,9 @@ private:
 private:
 	// Cache the action
 	ESLAssetAction Action;
+
+	// Cache the database name
+	FString TaskId;
 
 #if SL_WITH_LIBMONGO_C
 	// Server uri

--- a/Source/USemLog/Classes/Editor/SLAssetManager.h
+++ b/Source/USemLog/Classes/Editor/SLAssetManager.h
@@ -45,7 +45,16 @@ public:
 
 private:
 	// Move assets to folder
-	bool MoveAssets(const FString& Path);
+	bool MoveCurrentLevelAssets(const FString& Path);
+
+	// return the current level name 
+	FName GetCurrentLevel();
+
+	// Get the referenced assets and move them
+	void MoveReferencedObjects(FName PackageName, const FString& SourceBasePath, const FString& DestBasePath);
+
+	// Move the assets to destination path
+	void MoveAssets(TArray<FAssetData> AssetList, const FString& DestPath, const FString& SourcePath);
 
 protected:
 	// Set when initialized

--- a/Source/USemLog/Private/Editor/SLAssetDBHandler.cpp
+++ b/Source/USemLog/Private/Editor/SLAssetDBHandler.cpp
@@ -2,6 +2,10 @@
 // Author: Andrei Haidu (http://haidu.eu)
 
 #include "Editor/SLAssetDBHandler.h"
+#include "AssetRegistryModule.h"
+#include "AssetToolsModule.h"
+#include "HAL/PlatformFilemanager.h"
+
 
 // Ctor
 FSLAssetDBHandler::FSLAssetDBHandler() {}
@@ -12,12 +16,12 @@ bool FSLAssetDBHandler::Connect(const FString& DBName, const FString& ServerIp,
 {
 	Action = InAction;
 
-	if(Action != ESLAssetAction::Upload || Action != ESLAssetAction::Download)
+	if(Action != ESLAssetAction::Upload && Action != ESLAssetAction::Download)
 	{
 		UE_LOG(LogTemp, Warning, TEXT("%s::%d Wrong action type.."),
 			*FString(__func__), __LINE__);
 		return false;
-	}
+	}	
 
 	const FString CollName = DBName + ".assets";
 
@@ -51,9 +55,10 @@ bool FSLAssetDBHandler::Connect(const FString& DBName, const FString& ServerIp,
 
 	// Get a handle on the database "db_name" and collection "coll_name"
 	database = mongoc_client_get_database(client, TCHAR_TO_UTF8(*DBName));
-
+	TaskId = DBName;
+	
 	// Check if the collection already exists
-	if (Action == ESLAssetAction::Upload)
+	if (Action == ESLAssetAction::Upload || Action == ESLAssetAction::MoveAndUpload)
 	{
 		if (mongoc_database_has_collection(database, TCHAR_TO_UTF8(*CollName), &error))
 		{
@@ -67,6 +72,21 @@ bool FSLAssetDBHandler::Connect(const FString& DBName, const FString& ServerIp,
 						*FString(__func__), __LINE__, *FString(error.message));
 					return false;
 				}
+
+				// Create a new collection
+				bson_t noopt = BSON_INITIALIZER;
+
+				collection = mongoc_database_create_collection(database, TCHAR_TO_UTF8(*CollName), &noopt, &error);
+
+				if (collection == NULL)
+				{
+					UE_LOG(LogTemp, Error, TEXT("%s::%d Err.:%s"),
+						*FString(__func__), __LINE__, *FString(error.message));
+					return false;
+				}
+
+				UE_LOG(LogTemp, Warning, TEXT("%s::%d Successfully overwrite collection %s.%s for uploading assets .."),
+					*FString(__func__), __LINE__, *DBName, *CollName);
 			}
 			else
 			{
@@ -77,17 +97,50 @@ bool FSLAssetDBHandler::Connect(const FString& DBName, const FString& ServerIp,
 		}
 		else
 		{
-			UE_LOG(LogTemp, Warning, TEXT("%s::%d Creating collection %s.%s for uploading assets .."),
+			// Create a new collection
+			bson_t noopt = BSON_INITIALIZER;
+
+			collection = mongoc_database_create_collection(database, TCHAR_TO_UTF8(*CollName), &noopt, &error);
+
+			if (collection == NULL)
+			{
+				UE_LOG(LogTemp, Error, TEXT("%s::%d Err.:%s"),
+					*FString(__func__), __LINE__, *FString(error.message));
+				return false;
+			}
+			
+			UE_LOG(LogTemp, Warning, TEXT("%s::%d Successfully created collection %s.%s for uploading assets .."),
 				*FString(__func__), __LINE__, *DBName, *CollName);
 		}
 
 		// Create a gridfs handle prefixed by fs */
-		gridfs = mongoc_client_get_gridfs(client, TCHAR_TO_UTF8(*DBName), TCHAR_TO_UTF8(*CollName), &error);
+		gridfs = mongoc_client_get_gridfs(client, TCHAR_TO_UTF8(*DBName), "fs", &error);
 		if (!gridfs)
 		{
 			UE_LOG(LogTemp, Error, TEXT("%s::%d Err.:%s"),
 				*FString(__func__), __LINE__, *Uri, *FString(error.message));
 			return false;
+		}
+
+		if (bOverwrite)
+		{
+			mongoc_gridfs_file_list_t *list;
+			mongoc_gridfs_file_t *file_to_delete;
+			const bson_t query = BSON_INITIALIZER;
+
+			list = mongoc_gridfs_find(gridfs, &query);
+
+			file_to_delete = mongoc_gridfs_file_list_next(list);
+			while (file_to_delete != NULL) {
+				if (!mongoc_gridfs_file_remove(file_to_delete, &error))
+				{
+					UE_LOG(LogTemp, Error, TEXT("%s::%d Err.:%s"),
+						*FString(__func__), __LINE__, *Uri, *FString(error.message));
+					return false;
+				}
+				file_to_delete = mongoc_gridfs_file_list_next(list);
+			}
+			UE_LOG(LogTemp, Warning, TEXT("%s::%d Successfully clear gridfs"), *FString(__func__), __LINE__);
 		}
 	}
 	else if(Action == ESLAssetAction::Download)
@@ -97,6 +150,21 @@ bool FSLAssetDBHandler::Connect(const FString& DBName, const FString& ServerIp,
 		{
 			UE_LOG(LogTemp, Warning, TEXT("%s::%d Asset collection %s does not exist, skipping download.."),
 				*FString(__func__), __LINE__, *CollName);
+			return false;
+		}
+
+		// Set collection
+		collection = mongoc_client_get_collection(client, TCHAR_TO_UTF8(*DBName), TCHAR_TO_UTF8(*CollName));
+
+		UE_LOG(LogTemp, Warning, TEXT("%s::%d Successfully connected to the collection %s.%s for uploading assets .."),
+			*FString(__func__), __LINE__, *DBName, *CollName);
+
+		// Create a gridfs handle prefixed by fs */
+		gridfs = mongoc_client_get_gridfs(client, TCHAR_TO_UTF8(*DBName), "fs", &error);
+		if (!gridfs)
+		{
+			UE_LOG(LogTemp, Error, TEXT("%s::%d Err.:%s"),
+				*FString(__func__), __LINE__, *Uri, *FString(error.message));
 			return false;
 		}
 	}
@@ -221,19 +289,93 @@ void FSLAssetDBHandler::Execute()
 	}
 }
 
-//
+// Move current level and referenced asset to specific folder and upload to GridFS
 void FSLAssetDBHandler::Upload()
-{
+{	
+	UploadAllFileToGridFS(TEXT("/Game/SemLogAssets/") + TaskId + TEXT("/"));
 }
 
-//
+// Download level and asset from GridFS
 void FSLAssetDBHandler::Download()
 {
+#if SL_WITH_LIBMONGO_C
+	bson_error_t error;
+	const bson_t *doc;
+	mongoc_cursor_t *cursor;
+	bson_t *pipeline;
+
+	TMap<FString, FString> Files;
+	FString Path;
+	FString FileId;
+
+	pipeline = BCON_NEW("pipeline", "[",
+		"{",
+			"$match",
+			"{",
+				"files", "{", "$exists", BCON_BOOL(true), "}",
+			"}",
+		"}",
+		"]");
+
+	cursor = mongoc_collection_aggregate(
+		collection, MONGOC_QUERY_NONE, pipeline, NULL, NULL);
+
+	// change to if to load only one document
+	while (mongoc_cursor_next(cursor, &doc))
+	{
+		bson_iter_t iter;
+		bson_iter_t levels;
+
+		if (bson_iter_init(&iter, doc))
+		{
+			if (bson_iter_init(&iter, doc) && bson_iter_find(&iter, "files"))
+			{
+				bson_iter_t value;
+
+				if (bson_iter_recurse(&iter, &levels))
+				{
+					while (bson_iter_next(&levels))
+					{
+						if (bson_iter_recurse(&levels, &value) && bson_iter_find(&value, "file_id"))
+						{
+							char id[25];
+							bson_oid_to_string(bson_iter_oid(&value), id);
+							FileId = UTF8_TO_TCHAR(id);
+						}
+						if (bson_iter_recurse(&levels, &value) && bson_iter_find(&value, "path"))
+						{
+							Path = FString(bson_iter_utf8(&value, NULL));
+						}
+						Files.Add(FileId, Path);
+					}
+				}
+			}
+		}
+	}
+	// if there is error
+	if (mongoc_cursor_error(cursor, &error))
+	{
+		UE_LOG(LogTemp, Log, TEXT("Cursor Failure: %s"), *FString(error.message));
+	}
+	mongoc_cursor_destroy(cursor);
+	bson_destroy(pipeline);
+
+	//Create folder and download file	
+	for (auto& Elem : Files)
+	{
+		FString FilePath = Elem.Value;
+		FilePath.RemoveFromStart(TEXT("/Content/"));
+		IPlatformFile& PlatformFile = FPlatformFileManager::Get().GetPlatformFile();
+		PlatformFile.CreateDirectoryTree(*(FPaths::ProjectContentDir() + FilePath + TEXT("/")));
+		DownloadFileFromGridFS(FPaths::ConvertRelativePathToFull(FPaths::ProjectContentDir() + FilePath + TEXT("/")), Elem.Key);
+	}
+#endif
 }
 
 // Save image to gridfs, get the file oid and return true if succeeded
 bool FSLAssetDBHandler::AddToGridFs(const TArray<uint8>& InData, bson_oid_t* out_oid) const
 {
+#if SL_WITH_LIBMONGO_C
 	mongoc_gridfs_file_t *file;
 	mongoc_gridfs_file_opt_t file_opt = { 0 };
 	const bson_value_t* file_id_val;
@@ -285,4 +427,201 @@ bool FSLAssetDBHandler::AddToGridFs(const TArray<uint8>& InData, bson_oid_t* out
 	mongoc_gridfs_file_destroy(file);
 
 	return true;
+#endif
+}
+
+void FSLAssetDBHandler::UploadAllFileToGridFS(const FString& Dir)
+{
+	FAssetRegistryModule& AssetRegistryModule = FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry");
+	TArray<FAssetData> AllAsset;
+	AssetRegistryModule.Get().GetAssetsByPath(FName(*Dir), AllAsset, true, false);
+	TMap<FString, FString> Files;
+
+	for (FAssetData Data : AllAsset)
+	{
+		FString Path = Data.PackagePath.ToString();
+		Path.RemoveFromStart(TEXT("/Game/"));
+		FString ContentDir = FPaths::GameContentDir() + Path + TEXT("/");
+
+		FString Id;
+		if (Data.AssetClass.ToString().Equals(TEXT("World")))
+		{
+			UploadFileToGridFS(ContentDir, Data.AssetName.ToString() + TEXT(".umap"), Id);
+		}
+		else
+		{
+			UploadFileToGridFS(ContentDir, Data.AssetName.ToString() + TEXT(".uasset"), Id);
+		}
+		Files.Add(Id, TEXT("/Content/") + Path);
+		UE_LOG(LogTemp, Warning, TEXT("%s::%d fileid.: %s"),
+			*FString(__func__), __LINE__, *Id);
+	}
+
+	WriteFilesToDocument(Files);
+}
+
+bool FSLAssetDBHandler::UploadFileToGridFS(const FString& Path, const FString& FileName, FString& InId)
+{
+
+#if SL_WITH_LIBMONGO_C
+
+	bson_error_t error;
+	bson_value_t file_id;
+	mongoc_stream_t *file_stream;
+	mongoc_gridfs_bucket_t *bucket;
+
+	bucket = mongoc_gridfs_bucket_new(database, NULL, NULL, &error);
+	if (!bucket)
+	{
+		UE_LOG(LogTemp, Error, TEXT("%s::%d Err.:%s"),
+			*FString(__func__), __LINE__, *FString(error.message));
+		return false;
+	}
+
+	file_stream = mongoc_stream_file_new_for_path(TCHAR_TO_UTF8(*(Path + FileName)), O_RDONLY, 0);
+	if (!file_stream)
+	{
+		UE_LOG(LogTemp, Error, TEXT("%s::%d Err.: Can't open file stream"),
+			*FString(__func__), __LINE__);
+		return false;
+	}
+
+	bool result = mongoc_gridfs_bucket_upload_from_stream(
+		bucket, TCHAR_TO_UTF8(*FileName), file_stream, NULL, &file_id, &error);
+
+	if (!result)
+	{
+		UE_LOG(LogTemp, Error, TEXT("%s::%d Err.:%s"),
+			*FString(__func__), __LINE__, *FString(error.message));
+		return false;
+	}
+
+	//const bson_oid_t id = file_id.value.v_oid;
+	char id[25];
+	bson_oid_to_string(&file_id.value.v_oid, id);
+	InId = UTF8_TO_TCHAR(id);
+
+	mongoc_stream_close(file_stream);
+	mongoc_stream_destroy(file_stream);
+
+	return true;
+
+#else	
+	return false;
+#endif // SL_WITH_LIBMONGO_C
+}
+
+bool FSLAssetDBHandler::WriteFilesToDocument(TMap<FString, FString> Files)
+{
+#if SL_WITH_LIBMONGO_C
+
+	bson_t     *document;
+	bson_error_t error;
+	bson_oid_t oid;
+	bson_t *files;
+	bson_t *file_id;
+
+	document = bson_new();
+	files = bson_new();
+	file_id = bson_new();
+
+	bson_oid_init(&oid, NULL);
+	BSON_APPEND_OID(document, "_id", &oid);
+
+	BSON_APPEND_ARRAY_BEGIN(document, "files", files);
+	for (auto& Elem : Files)
+	{
+		BSON_APPEND_DOCUMENT_BEGIN(files, "file_id", file_id);
+		bson_oid_t id;
+		char* id_string = TCHAR_TO_ANSI(*Elem.Key);
+		bson_oid_init_from_string(&id, id_string);
+		BSON_APPEND_OID(file_id, "file_id", &id);
+		BSON_APPEND_UTF8(file_id, "path", TCHAR_TO_UTF8(*Elem.Value));
+		bson_append_document_end(files, file_id);
+	}
+	bson_append_array_end(document, files);
+
+	if (!mongoc_collection_insert_one(collection, document, NULL, NULL, &error)) {
+		UE_LOG(LogTemp, Error, TEXT("%s::%d Err.:%s"),
+			*FString(__func__), __LINE__, *FString(error.message));
+	}
+
+	bson_destroy(document);
+	bson_destroy(files);
+
+	return true;
+#else
+	return false;
+#endif // SL_WITH_LIBMONGO_C
+}
+
+bool FSLAssetDBHandler::DownloadFileFromGridFS(const FString& Path, const FString& Id)
+{
+#if SL_WITH_LIBMONGO_C
+	bson_error_t error;
+	mongoc_gridfs_file_t *file;
+	const bson_value_t* file_id;
+	mongoc_stream_t *file_stream;
+	mongoc_gridfs_bucket_t *bucket;
+
+	bson_t *file_query;
+	bson_oid_t id;
+
+	file_query = bson_new();
+
+	char* id_string = TCHAR_TO_ANSI(*Id);
+	bson_oid_init_from_string(&id, id_string);
+	BSON_APPEND_OID(file_query, "_id", &id);
+
+	if (gridfs == nullptr)
+		return false;
+
+	file = mongoc_gridfs_find_one(gridfs, file_query, &error);
+	if (!file)
+	{
+		UE_LOG(LogTemp, Error, TEXT("%s::%d Err.:%s"),
+			*FString(__func__), __LINE__, *FString(error.message));
+		return false;
+	}
+
+	file_id = mongoc_gridfs_file_get_id(file);
+
+	bucket = mongoc_gridfs_bucket_new(database, NULL, NULL, &error);
+	if (!bucket)
+	{
+		UE_LOG(LogTemp, Error, TEXT("%s::%d Err.:%s"),
+			*FString(__func__), __LINE__, *FString(error.message));
+		return false;
+	}
+
+	FString FileName = UTF8_TO_TCHAR(mongoc_gridfs_file_get_filename(file));
+	file_stream = mongoc_stream_file_new_for_path( TCHAR_TO_UTF8(*(Path+ FileName)), O_CREAT | O_RDWR, 0);
+	if (!file_stream)
+	{
+		if ((Path + FileName).Len() > 245) {
+			UE_LOG(LogTemp, Error, TEXT("%s::%d Err.: Can't open file stream, file path is too long"),
+				*FString(__func__), __LINE__);
+			return false;
+		}
+		UE_LOG(LogTemp, Error, TEXT("%s::%d Err.: Can't open file stream"),
+			*FString(__func__), __LINE__);
+		return false;
+	}
+
+	bool result = mongoc_gridfs_bucket_download_to_stream(
+		bucket, file_id, file_stream, &error);
+	if (!result) {
+		UE_LOG(LogTemp, Error, TEXT("%s::%d Err.:%s"),
+			*FString(__func__), __LINE__, *FString(error.message));
+		return EXIT_FAILURE;
+	}
+
+	mongoc_stream_close(file_stream);
+	mongoc_stream_destroy(file_stream);
+
+	return true;
+
+#else
+	return false;
+#endif // SL_WITH_LIBMONGO_C
 }

--- a/Source/USemLog/Private/Editor/SLAssetManager.cpp
+++ b/Source/USemLog/Private/Editor/SLAssetManager.cpp
@@ -2,6 +2,12 @@
 // Author: Andrei Haidu (http://haidu.eu)
 
 #include "Editor/SLAssetManager.h"
+#include "ModuleManager.h"
+#include "AssetRegistryModule.h"
+#include "EngineGlobals.h"
+#include "Engine/Engine.h"
+#include "Engine/World.h"
+#include "AssetToolsModule.h"
 
 // Ctor
 USLAssetManager::USLAssetManager()
@@ -35,19 +41,19 @@ void USLAssetManager::Init(const FString& TaskId, const FString& ServerIp,
 
 		if (Action == ESLAssetAction::Move)
 		{
-			// TODO
-			const FString Path = "SemLogAssets/"+ TaskId;
-			if (!MoveAssets(Path))
+			const FString Path = "/Game/SemLogAssets/"+ TaskId;
+			if (!MoveCurrentLevelAssets(Path))
 			{
+				UE_LOG(LogTemp, Error, TEXT("%s::%d Err.: Unable to move the assets"), *FString(__func__), __LINE__);
 				return;
 			}
 		}
 		else if (Action == ESLAssetAction::MoveAndUpload)
 		{
-			// TODO
-			const FString Path = "SemLogAssets/" + TaskId;
-			if (!MoveAssets(Path))
+			const FString Path = "/Game/SemLogAssets/" + TaskId;
+			if (!MoveCurrentLevelAssets(Path))
 			{
+				UE_LOG(LogTemp, Error, TEXT("%s::%d Err.: Unable to move the assets"), *FString(__func__), __LINE__);
 				return;
 			}
 
@@ -72,12 +78,10 @@ void USLAssetManager::Start()
 {
 	if (!bIsStarted && bIsInit)
 	{
-
 		if (Action == ESLAssetAction::Download || Action == ESLAssetAction::Upload)
 		{
 			DBHandler.Execute();
-		}		
-
+		}
 		bIsStarted = true;
 	}
 }
@@ -98,7 +102,152 @@ void USLAssetManager::Finish()
 }
 
 // Move assets to path
-bool USLAssetManager::MoveAssets(const FString & Path)
+bool USLAssetManager::MoveCurrentLevelAssets(const FString & Path)
 {
-	return false;
+	FAssetRegistryModule& AssetRegistryModule = FModuleManager::LoadModuleChecked<FAssetRegistryModule>(TEXT("AssetRegistry"));
+	TArray<FAssetData> AssetsList;
+	AssetRegistryModule.Get().GetAssetsByPackageName(GetCurrentLevel(), AssetsList);
+	MoveReferencedObjects(GetCurrentLevel(), TEXT("/Game"), Path);
+	MoveAssets(AssetsList, Path, TEXT("/Game"));
+	return true;
+}
+
+FName USLAssetManager::GetCurrentLevel()
+{
+	// Load Main Level Asset
+	ULevel* MainLevel = GetWorld()->GetCurrentLevel();
+
+	// Process asset path. Example:"/Game/UEDPIE_0_MapMain.MapMain:PersistentLevel" to "/Game/MapMain"
+	FString PackageName;
+	TArray<FString> RawPath, Temp1, Temp2;
+	MainLevel->GetPathName().ParseIntoArray(RawPath, *FString("/"), true);
+	RawPath.Top().ParseIntoArray(Temp1, *FString("."), true);
+	Temp1.Top().ParseIntoArray(Temp2, *FString(":"), true);
+
+	for (int i = 0; i < RawPath.Num() - 1; i++)
+	{
+		PackageName += TEXT("/") + RawPath[i];
+	}
+	PackageName += TEXT("/") + Temp2[0];
+
+	return FName(*PackageName);
+}
+
+void USLAssetManager::MoveReferencedObjects(FName PackageName, const FString& SourceBasePath, const FString& DestBasePath)
+{
+	FAssetRegistryModule& AssetRegistryModule = FModuleManager::LoadModuleChecked<FAssetRegistryModule>(TEXT("AssetRegistry"));
+
+	TArray<FName> HardDependencies;
+	AssetRegistryModule.Get().GetDependencies(PackageName, HardDependencies, EAssetRegistryDependencyType::Hard);
+
+	TArray<FName> SoftDependencies;
+	AssetRegistryModule.Get().GetDependencies(PackageName, SoftDependencies, EAssetRegistryDependencyType::Soft);
+
+	TArray<FAssetData> AssetsList;
+
+	if (HardDependencies.Num() > 0)
+	{
+		for (const FName HardDependency : HardDependencies)
+		{
+			if (HardDependency.ToString().StartsWith(TEXT("/Game/")) && !HardDependency.ToString().EndsWith(TEXT("BuiltData")))
+			{
+				if (AssetRegistryModule.Get().GetAssetsByPackageName(HardDependency, AssetsList))
+					MoveReferencedObjects(HardDependency, SourceBasePath, DestBasePath);
+			}
+		}
+	}
+
+	if (SoftDependencies.Num() > 0)
+	{
+		for (const FName SoftDependency : SoftDependencies)
+		{
+			if (SoftDependency.ToString().StartsWith(TEXT("/Game/")))
+			{
+				TArray<FAssetData> SoftAsset;
+				if (AssetRegistryModule.Get().GetAssetsByPackageName(SoftDependency, SoftAsset))
+				{
+					if (SoftDependency.ToString().Equals(PackageName.ToString())) {
+						continue;
+					}
+
+					if (SoftAsset.Last().AssetClass.ToString().Equals(TEXT("World")))
+					{
+						AssetsList.Add(SoftAsset.Last());
+						MoveReferencedObjects(SoftDependency, SourceBasePath, DestBasePath);
+					}
+				}
+			}
+		}
+	}
+
+	if (AssetsList.Num() > 0)
+	{
+		MoveAssets(AssetsList, DestBasePath, SourceBasePath);
+	}
+}
+
+void USLAssetManager::MoveAssets(TArray<FAssetData> AssetList, const FString& DestPath, const FString& SourcePath)
+{
+	TArray<UObject*> AssetObjects;
+	for (int32 AssetIdx = 0; AssetIdx < AssetList.Num(); ++AssetIdx)
+	{
+		const FAssetData& AssetData = AssetList[AssetIdx];
+
+		UObject* Obj = AssetData.GetAsset();
+		if (Obj)
+		{
+			AssetObjects.Add(Obj);
+		}
+	}
+
+	check(DestPath.Len() > 0);
+
+	FAssetToolsModule& AssetToolsModule = FModuleManager::LoadModuleChecked<FAssetToolsModule>("AssetTools");
+	TArray<FAssetRenameData> AssetsAndNames;
+	for (auto AssetIt = AssetObjects.CreateConstIterator(); AssetIt; ++AssetIt)
+	{
+		UObject* Asset = *AssetIt;
+
+		if (!ensure(Asset))
+		{
+			continue;
+		}
+
+		FString PackagePath;
+		FString ObjectName = Asset->GetName();
+
+		// Only a DestPath was supplied, use it
+		if (SourcePath.Len())
+		{
+			const FString CurrentPackageName = Asset->GetOutermost()->GetName();
+
+			// This is a relative operation
+			if (!ensure(CurrentPackageName.StartsWith(SourcePath)))
+			{
+				continue;
+			}
+
+			// Collect the relative path then use it to determine the new location
+			// For example, if SourcePath = /Game/MyPath and CurrentPackageName = /Game/MyPath/MySubPath/MyAsset
+			//     /Game/MyPath/MySubPath/MyAsset -> /MySubPath
+
+			const int32 ShortPackageNameLen = FPackageName::GetLongPackageAssetName(CurrentPackageName).Len();
+			const int32 RelativePathLen = CurrentPackageName.Len() - ShortPackageNameLen - SourcePath.Len() - 1; // -1 to exclude the trailing "/"
+			const FString RelativeDestPath = CurrentPackageName.Mid(SourcePath.Len(), RelativePathLen);
+
+			PackagePath = DestPath + RelativeDestPath;
+		}
+		else
+		{
+			// Only a DestPath was supplied, use it
+			PackagePath = DestPath;
+		}
+
+		new(AssetsAndNames) FAssetRenameData(Asset, PackagePath, ObjectName);
+	}
+
+	if (AssetsAndNames.Num() > 0)
+	{
+		AssetToolsModule.Get().RenameAssetsWithDialog(AssetsAndNames);
+	}
 }

--- a/Source/USemLog/Private/SLEditorLogger.cpp
+++ b/Source/USemLog/Private/SLEditorLogger.cpp
@@ -53,9 +53,7 @@ void USLEditorLogger::Init(const FString& InTaskId, const FString& ServerIp,
 void USLEditorLogger::Start(const FSLEditorLoggerParams& InParams)
 {
 	if (!bIsStarted && bIsInit)
-	{
-		bIsStarted = true;
-
+	{	
 		if (AssetManager)
 		{
 			AssetManager->Start();	
@@ -97,6 +95,8 @@ void USLEditorLogger::Start(const FSLEditorLoggerParams& InParams)
 				CalibrationTool->Start();
 			}
 		}
+
+		bIsStarted = true;
 	}
 }
 


### PR DESCRIPTION
Concerning issue with downloading assets from gridfs. If the file path is too long, it will fail.
[Problem] 
mongoc_stream_file_new_for_path (const char *path, int flags, int mode); The length of path is no longer than 250, otherwise it will fail to create new file, such that it can't download the file from gridfs.
[Solution] 
1. Passing absolute path to make the path shorter, using unreal function ConvertRelativePathToFull().
2. Check if the path length is longer than 250, return error, if it is.