### PR TITLE
Some errors that showed up on linux

### DIFF
--- a/Source/USemLog/Private/Data/SLIndividualUtils.cpp
+++ b/Source/USemLog/Private/Data/SLIndividualUtils.cpp
@@ -1,7 +1,7 @@
 // Copyright 2017-2020, Institute for Artificial Intelligence - University of Bremen
 // Author: Andrei Haidu (http://haidu.eu)
 
-#include "Data/SLindividualUtils.h"
+#include "Data/SLIndividualUtils.h"
 #include "Data/SLBaseIndividual.h"
 #include "Data/SLPerceivableIndividual.h"
 #include "Data/SLSkeletalIndividual.h"
@@ -22,7 +22,7 @@
 #include "Vision/SLVisionCamera.h"
 
 // Utils
-#include "Utils/SLUUid.h"
+#include "Utils/SLUuid.h"
 
 // Get class name of actor (if not known use label name if bDefaultToLabelName is true)
 FString FSLIndividualUtils::GetIndividualClassName(USLIndividualComponent* IndividualComponent, bool bDefaultToLabelName)
@@ -115,9 +115,9 @@ FString FSLIndividualUtils::GetIndividualClassName(USLIndividualComponent* Indiv
 			{
 				return "Linear" + ClassName;
 			}
-			else if (PCC->ConstraintInstance.GetAngularSwing1Motion() != ELinearConstraintMotion::LCM_Locked ||
-				PCC->ConstraintInstance.GetAngularSwing2Motion() != ELinearConstraintMotion::LCM_Locked ||
-				PCC->ConstraintInstance.GetAngularTwistMotion() != ELinearConstraintMotion::LCM_Locked)
+			else if (PCC->ConstraintInstance.GetAngularSwing1Motion() != EAngularConstraintMotion::ACM_Locked ||
+				PCC->ConstraintInstance.GetAngularSwing2Motion() != EAngularConstraintMotion::ACM_Locked ||
+				PCC->ConstraintInstance.GetAngularTwistMotion() != EAngularConstraintMotion::ACM_Locked)
 			{
 				return "Revolute" + ClassName;
 			}

--- a/Source/USemLog/Private/Data/SLIndividualVisualInfoComponent.cpp
+++ b/Source/USemLog/Private/Data/SLIndividualVisualInfoComponent.cpp
@@ -217,7 +217,7 @@ bool USLIndividualVisualInfoComponent::PointToCamera()
 	}
 	else if (APlayerController* PC = GetWorld()->GetFirstPlayerController())
 	{
-		PC->PlayerCameraManager;
+		//PC->PlayerCameraManager; // This will not call or yield anything
 	}
 
 	return false;

--- a/Source/USemLog/Private/Data/SLIndividualVisualInfoUtils.cpp
+++ b/Source/USemLog/Private/Data/SLIndividualVisualInfoUtils.cpp
@@ -1,7 +1,7 @@
 // Copyright 2017-2020, Institute for Artificial Intelligence - University of Bremen
 // Author: Andrei Haidu (http://haidu.eu)
 
-#include "Data/SLindividualVisualInfoUtils.h"
+#include "Data/SLIndividualVisualInfoUtils.h"
 #include "Data/SLBaseIndividual.h"
 #include "Data/SLPerceivableIndividual.h"
 #include "Data/SLSkeletalIndividual.h"

--- a/Source/USemLog/Private/Editor/SLEditorToolkit.cpp
+++ b/Source/USemLog/Private/Editor/SLEditorToolkit.cpp
@@ -545,9 +545,9 @@ FString FSLEditorToolkit::GenerateConstraintClassName(APhysicsConstraintActor* A
 		{
 			return "Linear"+DefaultValue;
 		}
-		else if (PCC->ConstraintInstance.GetAngularSwing1Motion() != ELinearConstraintMotion::LCM_Locked ||
-			PCC->ConstraintInstance.GetAngularSwing2Motion() != ELinearConstraintMotion::LCM_Locked ||
-			PCC->ConstraintInstance.GetAngularTwistMotion() != ELinearConstraintMotion::LCM_Locked)
+		else if (PCC->ConstraintInstance.GetAngularSwing1Motion() != EAngularConstraintMotion::ACM_Locked ||
+			PCC->ConstraintInstance.GetAngularSwing2Motion() != EAngularConstraintMotion::ACM_Locked ||
+			PCC->ConstraintInstance.GetAngularTwistMotion() != EAngularConstraintMotion::ACM_Locked)
 		{
 			return "Revolute" + DefaultValue;
 		}

--- a/Source/USemLogEd/Private/SLEdUtils.cpp
+++ b/Source/USemLogEd/Private/SLEdUtils.cpp
@@ -13,7 +13,7 @@
 
 // Utils
 #include "Utils/SLTagIO.h"
-#include "Utils/SLUUid.h"
+#include "Utils/SLUuid.h"
 
 // Write the semantic map
 void FSLEdUtils::WriteSemanticMap(UWorld* World, bool bOverwrite)


### PR DESCRIPTION
Some stuff that showed up when trying to use USemLog on Linux:
- Multiple includes that didn't match the filename casing on the filesystem
- The compiler highlighted that in Source/USemLog/Private/Data/SLIndividualUtils.cpp  there was a comparison between different types. Changed this so the corresponding things get compared
- Uncommented unecessary operation

