### PR TITLE
Loading websocket module and add comandline argument

### DIFF
--- a/Source/USemLog/Private/Knowrob/SLKRWSClient.cpp
+++ b/Source/USemLog/Private/Knowrob/SLKRWSClient.cpp
@@ -20,6 +20,11 @@ void FSLKRWSClient::Connect(const FString& InHost, int32 InPort, const FString& 
 {
 	TArray<FString> Protocols{ InProtocol };
 	const FString Url = TEXT("ws://") + InHost + TEXT(":") + FString::FromInt(InPort);
+	
+	if (!FModuleManager::Get().IsModuleLoaded("WebSockets"))
+	{
+		FModuleManager::Get().LoadModule("WebSockets");
+	}
 
 	// Clear any previous connection
 	if (WebSocket.IsValid())

--- a/Source/USemLog/Private/Knowrob/SLKnowrobManager.cpp
+++ b/Source/USemLog/Private/Knowrob/SLKnowrobManager.cpp
@@ -41,7 +41,14 @@ ASLKnowrobManager::~ASLKnowrobManager()
 void ASLKnowrobManager::BeginPlay()
 {
 	Super::BeginPlay();	
-	//Init();
+
+	FParse::Value(FCommandLine::Get(), TEXT("KRServerIP="), KRServerIP);
+	FParse::Value(FCommandLine::Get(), TEXT("KRServerPort="), KRServerPort);
+	FParse::Value(FCommandLine::Get(), TEXT("KRProtocol="), KRWSProtocol);
+	FParse::Value(FCommandLine::Get(), TEXT("MongoServerIP="), MongoServerIP);
+	FParse::Value(FCommandLine::Get(), TEXT("MongoServerPort="), MongoServerPort);
+
+	Init();
 	//Start();
 }
 


### PR DESCRIPTION
Fixed the fatal error caused by not loading the websocket module in packaged game.
Add commandline argument for specifying ip and port. If there is no argument, it will not change the variable and cause error